### PR TITLE
Modify version npm-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "axios": "^0.24.0",
     "node-gyp": "^8.4.1",
-    "node-sass": "^7.0.0",
+    "node-sass": "^8.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.3.0",


### PR DESCRIPTION
Current version of npm-sass is not compatible with the last version of Node.js. Changing the version to 8.0.0 fixes the problem.